### PR TITLE
Style dropdown menus universally

### DIFF
--- a/src/App/style.scss
+++ b/src/App/style.scss
@@ -217,8 +217,13 @@ textarea {
 
 select {
   @extend %link-button;
+  appearance: none;
   background-color: var(--bg-color);
   padding: 0.5rem;
-  border-radius: 0;
+  border-radius: 4px;
   cursor: pointer;
+  background-repeat: no-repeat;
+  background-image: linear-gradient(45deg, transparent 50%, currentColor 50%), linear-gradient(135deg, currentColor 50%, transparent 50%);
+  background-position: right 15px top 1.125em, right 10px top 1.125em;
+  background-size: 5px 5px, 5px 5px;
 }


### PR DESCRIPTION
Safari has an ugly default style for <select> elements. This styles them so they look better.